### PR TITLE
Update evince_synctex.py

### DIFF
--- a/evince_synctex.py
+++ b/evince_synctex.py
@@ -177,7 +177,7 @@ def startEvince(line, pdf_file, editor_command):
     try:
         EvinceWindowProxy.instance = EvinceWindowProxy(
             pdf_uri, editor_command, logger)
-        GLib.idle_add(poll_viewer_process)
+        GLib.timeout_add(1000,poll_viewer_process)
         GLib.MainLoop().run()
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
GLib.idle_add() fully loads one of the CPU cores making the script consume too much power (bad for my laptop's battery life and my personal sanity). Changed it to GLib.timeout_add() with 1 call per second, which seems often enough to be effective and battery friendly at the same time.